### PR TITLE
Update Spigot API version to 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <!-- Bukkit API Version, change if out dated -->
-            <version>1.8-R0.1-SNAPSHOT</version>
+            <version>1.10-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <type>jar</type>
         </dependency>


### PR DESCRIPTION
This commit updates Spigot API version to 1.10.
Compiled and verified locally, working OK in my Spigot 1.10 server.